### PR TITLE
Use start_soon as fork is deprecated in cocotb

### DIFF
--- a/src/test.py
+++ b/src/test.py
@@ -9,8 +9,8 @@ segments = [ 63, 6, 91, 79, 102, 109, 124, 7, 127, 103 ]
 async def test_7seg(dut):
     dut._log.info("start")
     clock = Clock(dut.clk, 10, units="us")
-    cocotb.fork(clock.start())
-    
+    cocotb.start_soon(clock.start())
+
     dut._log.info("reset")
     dut.rst.value = 1
     await ClockCycles(dut.clk, 10)


### PR DESCRIPTION
The docs on https://tinytapeout.com/hdl/testing/ also uses `start_soon` instead.