### PR TITLE
Use wildcard instead of explicitly listing v-files

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@
 SIM ?= icarus
 TOPLEVEL_LANG ?= verilog
 
-VERILOG_SOURCES += $(PWD)/tb.v $(PWD)/counter.v $(PWD)/decoder.v
+VERILOG_SOURCES += $(wildcard $(PWD)/*.v)
 
 # TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
 TOPLEVEL = tb


### PR DESCRIPTION
A little late to the party,  but this change leaves one fewer place to update when forking for a new design.