### PR TITLE
Add workflow for automatic gate-level testing

### DIFF
--- a/.github/workflows/gds.yaml
+++ b/.github/workflows/gds.yaml
@@ -58,6 +58,17 @@ jobs:
     - name: show files
       run: find runs/wokwi/
 
+    # extract gate-level verilog
+    - name: extract gate-level verilog
+      run: |
+        cp `find runs/wokwi/results/final/verilog/gl/*.v` runs/gatelevel.v
+
+    # upload gate-level verilog
+    - uses: actions/upload-artifact@v3
+      with:
+        name: gatelevel.v
+        path: runs/gatelevel.v
+
     # print some routing stats
     - name: add summary
       run: ./configure.py --get-stats >> $GITHUB_STEP_SUMMARY
@@ -79,6 +90,28 @@ jobs:
       with:
         path: runs
         key: ${{ runner.os }}-runs-${{ github.run_id }}
+
+  gatelevel:
+    needs: gds
+    runs-on: ubuntu-latest
+    container:
+      image: davidsiaw/ocs
+      env:
+        GATES: yes
+        PDK_ROOT: /opt/pdk
+    steps:
+    - name: checkout repo
+      uses: actions/checkout@v3
+    - uses: actions/download-artifact@v3
+      with:
+        name: gatelevel.v
+        path: src/gatelevel-src
+    - name: run gate level test
+      run: |
+        cd src
+        ls
+        cp gatelevel-src/gatelevel.v gatelevel.v
+        make
 
   png:
     needs: gds

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,24 @@
 SIM ?= icarus
 TOPLEVEL_LANG ?= verilog
 
-VERILOG_SOURCES += $(PWD)/tb.v $(PWD)/counter.v $(PWD)/decoder.v
+ifneq ($(GATES),yes)
+# normal simulation
+VERILOG_SOURCES=$(wildcard $(PWD)/*.v)
+
+else
+# copy the gatelevel verilog from /runs/wokwi/results/final/verilog/gl/ and commit to this directory
+VERILOG_SOURCES=$(PWD)/tb.v $(PWD)/gatelevel.v
+
+# gate level simulation requires some extra setup
+COMPILE_ARGS    += -DGL_TEST
+COMPILE_ARGS    += -DFUNCTIONAL
+COMPILE_ARGS    += -DUSE_POWER_PINS
+COMPILE_ARGS    += -DSIM
+COMPILE_ARGS    += -DUNIT_DELAY=#1
+COMPILE_ARGS    += -DSIM
+VERILOG_SOURCES += $(PDK_ROOT)/sky130B/libs.ref/sky130_fd_sc_hd/verilog/primitives.v
+VERILOG_SOURCES += $(PDK_ROOT)/sky130B/libs.ref/sky130_fd_sc_hd/verilog/sky130_fd_sc_hd.v
+endif
 
 # TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
 TOPLEVEL = tb
@@ -15,4 +32,3 @@ MODULE = test
 
 # include cocotb's make rules to take care of the simulator setup
 include $(shell cocotb-config --makefiles)/Makefile.sim
-

--- a/src/tb.v
+++ b/src/tb.v
@@ -26,7 +26,16 @@ module tb (
     assign segments = outputs[6:0];
 
     // instantiate the DUT
-    seven_segment_seconds #(.MAX_COUNT(100)) seven_segment_seconds(
+    seven_segment_seconds #(
+`ifndef GL_TEST
+        .MAX_COUNT(100)
+`endif
+        ) seven_segment_seconds (
+`ifdef GL_TEST
+        // for gatelevel testing we need to set up the power pins
+        .vccd1(1'b1),
+        .vssd1(1'b0),
+`endif
         .io_in  (inputs),
         .io_out (outputs)
         );


### PR DESCRIPTION
This is an additional workflow to allow gate-level testing to be done automatically after cell placement. It uses most of the stuff from Matt's gatelevel branch. This allows us to avoid having to download the result of the `gds` step and extract the `gate-level.v` file manually.

This branch uses my `davidsiaw/ocs` docker image. For more info please go to https://github.com/davidsiaw/ocs